### PR TITLE
Fix/queue tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ See https://circleci.com/orbs/registry/orb/eddiewebb/queue#usage-examples for cu
 ## Note
 
 Queueing is not supported on forked repos. If a queue from a fork happens the queue will immediately exit and the next step of the job will begin.
+
+## RealSelf fork changes
+
+Forked `eddiewebb/queue@1.5.0`. Fixed a bug when a git tag is released and the env variable `CIRCLE_BRANCH` is unset. Now there is a parameter `circle-branch` that by default has `main` as value, but can be set to any other branch name so that it doesn't break queueing in non-main branches.
+
+### Deployment steps
+```
+# Pack and validate orb
+brew install circleci
+circleci config pack src/ > pack.yml
+circleci orb validate pack.yml
+
+# Only for first time creation
+circleci orb create realself/upload-source-maps
+
+# Push orb (change version to latest)
+circleci orb publish ./orb.yml realself/queue@1.0.0
+```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ circleci config pack src/ > pack.yml
 circleci orb validate pack.yml
 
 # Only for first time creation
-circleci orb create realself/upload-source-maps
+circleci orb create realself/queue
 
 # Push orb (change version to latest)
 circleci orb publish ./orb.yml realself/queue@1.0.0

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ circleci orb validate pack.yml
 circleci orb create realself/queue
 
 # Push orb (change version to latest)
-circleci orb publish ./orb.yml realself/queue@1.0.0
+circleci orb publish ./pack.yml realself/queue@X.X.X
 ```

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -32,6 +32,11 @@ parameters:
     type: env_var_name
     default: CIRCLECI_API_KEY
     description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
+  # RealSelf FIX
+  circle-branch: 
+    type: string
+    default: "main"
+    description: "If a tag is released, CIRCLE_BRANCH becomes empty (and CIRCLE_TAG gets a value), breaking the orb. This parameter helps avoid this by setting 'main' as the default value for CIRCLE_BRANCH, giving the flexibility to set it to a different branch if needed."
 steps:
   - run:
       name: Queue Until Front of Line
@@ -44,11 +49,19 @@ steps:
           : ${CIRCLE_PROJECT_REPONAME:?"Required Env Variable not found!"}
           : ${CIRCLE_REPOSITORY_URL:?"Required Env Variable not found!"}
           : ${CIRCLE_JOB:?"Required Env Variable not found!"}
+
+          # RealSelf FIX
+          if [ -z "${CIRCLE_BRANCH}" ]; then
+            echo "CIRCLE_BRANCH not set. Using set or default value from parameters: ${<< parameters.circle-branch >>}"
+            CIRCLE_BRANCH="<<parameters.circle-branch>>"
+          fi
           # Only needed for private projects
           if [ -z "${<< parameters.circleci-api-key >>}" ]; then
             echo "<< parameters.circleci-api-key >> not set. Private projects will be inaccessible."
           fi
           VCS_TYPE="<<parameters.vcs-type>>"
+
+
         }
 
 

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -32,6 +32,11 @@ parameters:
     type: env_var_name
     default: CIRCLECI_API_KEY
     description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
+  # RealSelf FIX
+  circle-branch:
+    type: string
+    default: "main"
+    description: "If a tag is released, CIRCLE_BRANCH becomes empty (and CIRCLE_TAG gets a value), breaking the orb. This parameter helps avoid this by setting 'main' as the default value for CIRCLE_BRANCH, giving the flexibility to set it to a different branch if needed."
 
 docker:
   - image: cimg/base:stable
@@ -46,3 +51,5 @@ steps:
       vcs-type: <<parameters.vcs-type>>
       confidence: <<parameters.confidence>>
       circleci-api-key: <<parameters.circleci-api-key>>
+      # RealSelf FIX
+      circle-branch: <<parameters.circle-branch>>


### PR DESCRIPTION
With this change, which has been published here: https://circleci.com/developer/orbs/orb/realself/queue?version=1.1.0
we can now queue tagged workflows and not-tagged workflows (ex. commits or PR merges). 